### PR TITLE
update readme.md and add result to exported types

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,31 @@ Thirth you see that the reporters class requires an log method. This is the meth
 | args      | []     | An array of all other arguments that are given to LogHandler                                                                                              |
 | createdAt | Date   | The exact date when LogHandler received the logevent                                                                                                      |
 
+### How to enable a reporter
+Enabling a reporter that you downloaded or just created by yourself isn't hard. To add a reporter to the list of reporters that are used by loghandler can be easly done by adding the reporter to the list of reporters in the Loghandler options. Emample: 
+```
+import loghandler from 'loghandler'
+import example_reporter from 'example_reporter'
 
+const config = {
+  reporters: [
+    new example_reporter(),
+  ]
+  reporting: {
+    silent: false
+    minimalLevel2Report: 'debug'
+  }
+}
+
+const log = loghandler(config)
+
+
+try{
+  throw new Error("Something goes wrong!")
+}catch(err){
+  log.emerg(err)
+}
+```
 
 ### List of publicly available reporters
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,5 +17,5 @@ export type ReportersInterface = ReportersInterface
 export type Config = Config
 export type LogObjectInterface = LogObjectInterface
 export type LogLevels = LogLevels
-export type Results = LogHandlerResults
+export type Log = LogHandlerResults
 export const logLevelsKeys = LogLevelsKeysList

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import {
   LogObjectInterface,
   LogLevels,
   LogLevelsKeys as LogLevelsKeysList,
+  LogHandlerResults,
 } from './interfaces'
 
 const logHandler = function(config: Config) {
@@ -16,4 +17,5 @@ export type ReportersInterface = ReportersInterface
 export type Config = Config
 export type LogObjectInterface = LogObjectInterface
 export type LogLevels = LogLevels
+export type Results = LogHandlerResults
 export const logLevelsKeys = LogLevelsKeysList


### PR DESCRIPTION
I updated the readme.md, because the readme didn't explain how to add a reporter to logHandler. Second I expored the typings for the logging object. The typing of the loaded LogHandler module can be loaded by importing Log. Example:

```
import logHandler, {Log} from 'loghandler'
```

Signed-off-by: Michel Bitter <michel@michelbitter.nl>